### PR TITLE
メッセージ送信機能の実装(ヘッダー表示)

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,9 +2,10 @@
   .main-chat__header
     %ul.main-chat__header__left
       %li.main-chat__header__left__groupname
-        = @group
+        = @group.name
       %li.main-chat__header__left__membername
-        = current_user.name
+        - @group.group_users.each do |group_user|
+          = group_user.user.name
     .main-chat__header__edit-btn Edit
 
   .main-chat__messages


### PR DESCRIPTION
# What
メインチャットのヘッダーに所属グループ名、メンバー名を表示させる。

# Why
現在、所属しているグループ名、メンバー名を分かるようにする為。