### PR TITLE
Uglifierのコメントアウト

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
*config/production.rb*内のUglifierの記述をコメントアウトする。

# Why
JavaScriptで使用しているテンプレートリテラル記法（`）に対応していない為、デプロイ時のエラー対策。